### PR TITLE
support iTerm 2.app for 256 color mode detection

### DIFF
--- a/lib/tty/color/mode.rb
+++ b/lib/tty/color/mode.rb
@@ -3,7 +3,7 @@
 module TTY
   module Color
     class Mode
-      TERM_256 = /iTerm.app/x
+      TERM_256 = /iTerm(\s\d+){0,1}.app/x
 
       TERM_64 = /^(hpterm-color|wy370|wy370-105k|wy370-EPC|wy370-nk|
                  wy370-rv|wy370-tek|wy370-vb|wy370-w|wy370-wvb)$/x

--- a/spec/unit/mode_spec.rb
+++ b/spec/unit/mode_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe TTY::Color::Mode, 'detecting mode' do
       expect(mode.from_term).to eq(256)
     end
 
+    it 'infers mode for iTerm 2.app' do
+      mode = described_class.new('TERM' => 'iTerm 2.app')
+      expect(mode.from_term).to eq(256)
+    end
+
     it 'infers mode from terminal environment' do
       mode = described_class.new('TERM' => 'amiga-8bit')
       expect(mode.from_term).to eq(256)


### PR DESCRIPTION
Extended regexp to detect "iTerm 2.app" in addition to "iTerm.app" for 256 color mode.