### PR TITLE
Add support for NO_COLOR (see https://no-color.org/)

### DIFF
--- a/lib/tty/color.rb
+++ b/lib/tty/color.rb
@@ -31,6 +31,16 @@ module TTY
     alias color? support?
     alias supports_color? support?
 
+    # Detect if color support has been disabled with NO_COLOR ENV var.
+    #
+    # @return [Boolean]
+    #   true when terminal color support has been disabled, false otherwise
+    #
+    # @api public
+    def disabled?
+      Support.new(ENV, verbose: verbose).disabled?
+    end
+
     # Check how many colors this terminal supports
     #
     # @return [Integer]

--- a/lib/tty/color/support.rb
+++ b/lib/tty/color/support.rb
@@ -21,12 +21,24 @@ module TTY
       # @api public
       def support?
         return false unless TTY::Color.tty?
+        return false if disabled?
 
         value = false
         SOURCES.each do |from_check|
           break if (value = public_send(from_check)) != NoValue
         end
         value == NoValue ? false : value
+      end
+
+      # Detect if color support has been disabled with NO_COLOR ENV var.
+      #
+      # @return [Boolean]
+      #   true when terminal color support has been disabled, false otherwise
+      #
+      # @api public
+      def disabled?
+        no_color = @env["NO_COLOR"]
+        !(no_color.nil? || no_color.empty?)
       end
 
       # Inspect environment $TERM variable for color support

--- a/spec/unit/color_spec.rb
+++ b/spec/unit/color_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe TTY::Color, "integratation" do
 
     expect(support_instance).to have_received(:support?)
   end
+
+  it "accesses disabled support" do
+    support_instance = spy(:support, disabled?: :maybe)
+    allow(TTY::Color::Support).to receive(:new).and_return(support_instance)
+
+    expect(described_class.disabled?).to eq(:maybe)
+
+    expect(support_instance).to have_received(:disabled?)
+  end
+
 end

--- a/spec/unit/support_spec.rb
+++ b/spec/unit/support_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe TTY::Color::Support, "#support?" do
     expect(support.support?).to eq(false)
   end
 
+  it "disables color support when NO_COLOR is set" do
+    support = described_class.new({"NO_COLOR" => "1"})
+    expect(support.support?).to eq(false)
+    expect(support).to be_disabled
+  end
+
   it "fails to find out color support" do
     support = described_class.new({})
     allow(TTY::Color).to receive(:tty?).and_return(true)


### PR DESCRIPTION
As documented at https://no-color.org: "By adopting this standard, users that prefer to have plain, non-colored text output can set one environment variable in their shell to have it automatically affect all supported software."  By placing this here at the terminal support check layer, dependent applications can support `NO_COLOR` without any changes.

I chose to only add it to `Support`. Although a case could be made for adding it to `Mode` as well, there may be circumstances when it is useful to query for how many colors the terminal supports, even if opting out of using them.