### PR TITLE
Add 24bit color aka "direct color" aka "truecolor"

### DIFF
--- a/lib/tty/color.rb
+++ b/lib/tty/color.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "color/support"
 require_relative "color/mode"
+require_relative "color/support"
 require_relative "color/version"
 
 module TTY

--- a/lib/tty/color/mode.rb
+++ b/lib/tty/color/mode.rb
@@ -56,7 +56,7 @@ module TTY
       # @api private
       def from_term
         case @env["TERM"]
-        when TERM_24bit then TRUECOLORS
+        when TERM_24BIT then TRUECOLORS
         when /[\-\+](\d+)color/ then $1.to_i
         when /[\-\+](\d+)bit/   then 2 ** $1.to_i
         when TERM_256 then 256

--- a/lib/tty/color/mode.rb
+++ b/lib/tty/color/mode.rb
@@ -3,7 +3,7 @@
 module TTY
   module Color
     class Mode
-      TERM_24bit = /[+-]direct/
+      TERM_24BIT = /[+-]direct/
       TRUECOLORS = 2 ** 24 # 8 bits per RGB channel
 
       TERM_256 = /^(alacritty|iTerm\s?\d*\.app|kitty|mintty|ms-terminal|

--- a/lib/tty/color/mode.rb
+++ b/lib/tty/color/mode.rb
@@ -3,7 +3,12 @@
 module TTY
   module Color
     class Mode
-      TERM_256 = /iTerm(\s\d+){0,1}.app/x
+      TERM_24bit = /[+-]direct/
+      TRUECOLORS = 2 ** 24 # 8 bits per RGB channel
+
+      TERM_256 = /^(alacritty|iTerm\s?\d*\.app|kitty|mintty|ms-terminal|
+                    nsterm|nsterm-build\d+|terminator|terminology(-[0-9.]+)?|
+                    termite|vscode)$/x
 
       TERM_64 = /^(hpterm-color|wy370|wy370-105k|wy370-EPC|wy370-nk|
                  wy370-rv|wy370-tek|wy370-vb|wy370-w|wy370-wvb)$/x
@@ -15,7 +20,7 @@ module TTY
                  d430c-unix-s|d430c-unix-sr|d430c-unix-w|d470|d470-7b|d470-dg|
                  d470c|d470c-7b|d470c-dg|dg+color|dg\+fixed|dgunix\+fixed|
                  dgmode\+color|hp\+color|ncr260wy325pp|ncr260wy325wpp|
-                 ncr260wy350pp|ncr260wy350wpp|nsterm|nsterm-c|nsterm-c-acs|
+                 ncr260wy350pp|ncr260wy350wpp|nsterm-c|nsterm-c-acs|
                  nsterm-c-s|nsterm-c-s-7|nsterm-c-s-acs|nsterm\+c|
                  nsterm-7-c|nsterm-bce)$/x
 
@@ -30,7 +35,7 @@ module TTY
       # Detect supported colors
       #
       # @return [Integer]
-      #   out of 0, 8, 16, 52, 64, 256
+      #   out of 0, 8, 16, 52, 66, 256, 2^24
       #
       # @api public
       def mode
@@ -51,6 +56,7 @@ module TTY
       # @api private
       def from_term
         case @env["TERM"]
+        when TERM_24bit then TRUECOLORS
         when /[\-\+](\d+)color/ then $1.to_i
         when /[\-\+](\d+)bit/   then 2 ** $1.to_i
         when TERM_256 then 256

--- a/lib/tty/color/support.rb
+++ b/lib/tty/color/support.rb
@@ -6,6 +6,25 @@ module TTY
       SOURCES = %w[from_term from_tput from_env from_curses].freeze
       ENV_VARS = %w[COLORTERM ANSICON].freeze
 
+      TERM_REGEX = /
+        color|  # explicitly claims color support in the name
+        direct| # explicitly claims "direct color" (24 bit) support
+
+        #{Mode::TERM_256}|
+        #{Mode::TERM_64}|
+        #{Mode::TERM_52}|
+        #{Mode::TERM_16}|
+        #{Mode::TERM_8}|
+
+        ^ansi(\.sys.*)?$|
+        ^cygwin|
+        ^linux|
+        ^putty|
+        ^rxvt|
+        ^screen|
+        ^tmux|
+        ^xterm /xi
+
       # Initialize a color support
       # @api public
       def initialize(env, verbose: false)
@@ -35,7 +54,7 @@ module TTY
       def from_term
         case @env["TERM"]
         when "dumb" then false
-        when /^screen|^xterm|^vt100|color|ansi|cygwin|linux/i then true
+        when TERM_REGEX then true
         else NoValue
         end
       end

--- a/spec/unit/mode_spec.rb
+++ b/spec/unit/mode_spec.rb
@@ -27,7 +27,16 @@ RSpec.describe TTY::Color::Mode, "detecting mode" do
 
   context "#from_term" do
     {
+      "xterm+direct" => 16777216,
+      "vscode-direct" => 16777216,
       "xterm-256color" => 256,
+      "alacritty" => 256,
+      "mintty" => 256,
+      "ms-terminal" => 256,
+      "nsterm" => 256,
+      "nsterm-build400" => 256,
+      "terminator" => 256,
+      "vscode" => 256,
       "iTerm.app" => 256,
       "iTerm 2.app" => 256,
       "amiga-8bit" => 256,

--- a/spec/unit/mode_spec.rb
+++ b/spec/unit/mode_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe TTY::Color::Mode, "detecting mode" do
 
   context "#from_term" do
     {
-      "xterm+direct" => 16777216,
-      "vscode-direct" => 16777216,
+      "xterm+direct" => 16_777_216,
+      "vscode-direct" => 16_777_216,
       "xterm-256color" => 256,
       "alacritty" => 256,
       "mintty" => 256,

--- a/spec/unit/support_spec.rb
+++ b/spec/unit/support_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe TTY::Color::Support, "#support?" do
     end
   end
 
-  context "#form_term" do
+  context "#from_term" do
     it "fails to find color for dumb terminal" do
       support = described_class.new({"TERM" => "dumb"})
       expect(support.from_term).to eq(false)
@@ -92,6 +92,8 @@ RSpec.describe TTY::Color::Support, "#support?" do
 
     it "inspects term variable for color capabilities" do
       support = described_class.new({"TERM" => "xterm"})
+      expect(support.from_term).to eq(true)
+      support = described_class.new({"TERM" => "tmux-256color"})
       expect(support.from_term).to eq(true)
     end
 


### PR DESCRIPTION
In addition to truecolor support based on `TERM`, this also adds some new 256 color TERMs to `Mode::TERM_256` and used the mode Regexps inside the support Regexp. This required swapping the require order, because Support now depends on those Regexps from Mode.

I matched this up with my local laptop's terminfo DB (Ubuntu 20.04, with ncurses 6.2.20200212, and a bunch of extra terminal packages installed).

I did make "ansi" support more conservative and added "^" to a few of the other support cases which _might_ lead to some false negatives, but `tput` should still be a reliable fallback for those. A few other matches became more liberal and might lead to new false matches, but only when it correctly matches popular modern terminals though it may incorrectly match very old (presumably uncommon) releases.

To query terminfo, I ran the following bash script and several like it:

```bash
for term in $(toe -a | awk '{ print $1 }' | sort -u | xargs); do
    printf "%3d %s\n" "$(TERM="$term" tput colors)" "$term"
done | sort -n
```